### PR TITLE
2.0.2 Release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ variables:
   solution: '**/*.sln'
   majorVersion: '2'
   minorVersion: '0'
-  patchVersion: '1'
+  patchVersion: '2'
   version: '$(majorVersion).$(minorVersion).$(patchVersion)'
 
 steps:

--- a/src/MooVC.Architecture.Tests/Ddd/ReferenceTests/WhenReferenceEqualityIsChecked.cs
+++ b/src/MooVC.Architecture.Tests/Ddd/ReferenceTests/WhenReferenceEqualityIsChecked.cs
@@ -6,6 +6,17 @@
     public class WhenReferenceEqualityIsChecked
     {
         [Fact]
+        public void GivenAVersionedReferencedAndANonVersionedReferenceThatHaveToTheSameIdAndTypeThenBothAreConsideredEqual()
+        {
+            var aggregateId = Guid.NewGuid();
+
+            var first = new Reference<AggregateRoot>(aggregateId);
+            var second = new VersionedReference<AggregateRoot>(aggregateId);
+
+            Assert.True(first == second);
+        }
+
+        [Fact]
         public void GivenTwoSeparateInstancesWithTheSameIdAndTypeThenBothAreConsideredEqual()
         {
             var aggregateId = Guid.NewGuid();

--- a/src/MooVC.Architecture.Tests/Ddd/VersionedReferenceTests/WhenReferenceEqualityIsChecked.cs
+++ b/src/MooVC.Architecture.Tests/Ddd/VersionedReferenceTests/WhenReferenceEqualityIsChecked.cs
@@ -6,6 +6,17 @@
     public class WhenReferenceEqualityIsChecked
     {
         [Fact]
+        public void GivenAVersionedReferencedAndANonVersionedReferenceThatHaveToTheSameIdAndTypeThenBothAreConsideredEqual()
+        {
+            var aggregateId = Guid.NewGuid();
+
+            var first = new VersionedReference<AggregateRoot>(aggregateId);
+            var second = new Reference<AggregateRoot>(aggregateId);
+
+            Assert.True(first == second);
+        }
+
+        [Fact]
         public void GivenTwoSeparateInstancesWithTheSameIdAndTypeAndVersionThenBothAreConsideredEqual()
         {
             var aggregateId = Guid.NewGuid();
@@ -33,8 +44,8 @@
         {
             var aggregateId = Guid.NewGuid();
 
-            var first = new Reference<AggregateRoot>(aggregateId);
-            var second = new Reference<EventCentricAggregateRoot>(aggregateId);
+            var first = new VersionedReference<AggregateRoot>(aggregateId);
+            var second = new VersionedReference<EventCentricAggregateRoot>(aggregateId);
 
             Assert.False(first == second);
         }

--- a/src/MooVC.Architecture/Ddd/Reference.cs
+++ b/src/MooVC.Architecture/Ddd/Reference.cs
@@ -34,12 +34,14 @@ namespace MooVC.Architecture.Ddd
         {
             return NotEqualOperator(first, second);
         }
-        
+
         private static bool EqualOperator(Reference left, Reference right)
         {
             return left is null ^ right is null 
                 ? false 
-                : left is null || left.Equals(right);
+                : left is null 
+                    ? true 
+                    : left.Id == right.Id && left.Type == right.Type;
         }
 
         private static bool NotEqualOperator(Reference left, Reference right)
@@ -49,9 +51,7 @@ namespace MooVC.Architecture.Ddd
 
         public override bool Equals(object other)
         {
-            return other is Reference value 
-                ? Id == value.Id && Type == value.Type 
-                : false;
+            return EqualOperator(this, other as Reference);
         }
 
         public override int GetHashCode()

--- a/src/MooVC.Architecture/MooVC.Architecture.csproj
+++ b/src/MooVC.Architecture/MooVC.Architecture.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/MooVC/moovc.architecture.git</RepositoryUrl>
     <PackageProjectUrl>https://github.com/MooVC/moovc.architecture</PackageProjectUrl>
     <Description>A framework designed to support the rapid development of applications that adhere to the Domain Driven Design architectural style.</Description>
-    <Version>2.0.1</Version>
+    <Version>2.0.2</Version>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
<b>Bug Fixes</b>
<ul>
<li>Fixed a bug whereby the order of an equality check involving a VersionedReference and a Reference produced different results contrary to intention.</li>
</ul>