### PR TITLE
3.0.1 Release

### DIFF
--- a/src/MooVC.Architecture/Ddd/Services/DefaultAggregateReconciler.cs
+++ b/src/MooVC.Architecture/Ddd/Services/DefaultAggregateReconciler.cs
@@ -56,12 +56,7 @@
                 events = RemovePreviousVersions(events, existing.Version);
             }
 
-            if (events.Any())
-            {
-                existing.LoadFromHistory(events);
-
-                proxy.Save(existing);
-            }
+            Apply(existing, events, proxy);
         }
     }
 }


### PR DESCRIPTION
<b>Bug Fixes</b>
<ul>
<li>AggregateHistoryInvalidForStateException and AggregateConflictDetectedException are now recognized as Conflicts by the DefaultAggregateReconciler.</li>
</ul>