### PR TITLE
4.0.0: Release

### DIFF
--- a/src/MooVC.Architecture/Ddd/Services/AggregateConflictDetectedEventArgs.cs
+++ b/src/MooVC.Architecture/Ddd/Services/AggregateConflictDetectedEventArgs.cs
@@ -12,7 +12,7 @@
         : EventArgs
     {
         internal AggregateConflictDetectedEventArgs(
-            VersionedReference aggregate,
+            Reference aggregate,
             IEnumerable<DomainEvent> events,
             SignedVersion next,
             SignedVersion previous)
@@ -28,7 +28,7 @@
             Previous = previous;
         }
 
-        public VersionedReference Aggregate { get; }
+        public Reference Aggregate { get; }
 
         public IEnumerable<DomainEvent> Events { get; }
 

--- a/src/MooVC.Architecture/Ddd/Services/AggregateReconciledEventArgs.cs
+++ b/src/MooVC.Architecture/Ddd/Services/AggregateReconciledEventArgs.cs
@@ -1,0 +1,29 @@
+﻿namespace MooVC.Architecture.Ddd.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using MooVC.Architecture.Ddd;
+    using static MooVC.Architecture.Ddd.Ensure;
+    using static MooVC.Ensure;
+    using static Resources;
+
+    public sealed class AggregateReconciledEventArgs
+        : EventArgs
+    {
+        internal AggregateReconciledEventArgs(
+            Reference aggregate,
+            IEnumerable<DomainEvent> events)
+        {
+            ReferenceIsNotEmpty(aggregate, nameof(aggregate), AggregateReconciledEventArgsAggregateRequired);
+            ArgumentIsAcceptable(events, nameof(events), value => value.Any(), AggregateReconciledEventArgsEventsRequired);
+
+            Aggregate = aggregate;
+            Events = events;
+        }
+
+        public Reference Aggregate { get; }
+
+        public IEnumerable<DomainEvent> Events { get; }
+    }
+}

--- a/src/MooVC.Architecture/Ddd/Services/AggregateReconciledEventHandler.cs
+++ b/src/MooVC.Architecture/Ddd/Services/AggregateReconciledEventHandler.cs
@@ -1,0 +1,4 @@
+﻿namespace MooVC.Architecture.Ddd.Services
+{
+    public delegate void AggregateReconciledEventHandler(IAggregateReconciler sender, AggregateReconciledEventArgs e);
+}

--- a/src/MooVC.Architecture/Ddd/Services/DefaultAggregateReconciler.cs
+++ b/src/MooVC.Architecture/Ddd/Services/DefaultAggregateReconciler.cs
@@ -56,7 +56,7 @@
                 events = RemovePreviousVersions(events, existing.Version);
             }
 
-            Apply(existing, events, proxy);
+            Apply(existing, events, proxy, aggregate);
         }
     }
 }

--- a/src/MooVC.Architecture/Ddd/Services/IAggregateReconciler.cs
+++ b/src/MooVC.Architecture/Ddd/Services/IAggregateReconciler.cs
@@ -6,6 +6,8 @@
     {
         event AggregateConflictDetectedEventHandler AggregateConflictDetected;
 
+        event AggregateReconciledEventHandler AggregateReconciled;
+
         event UnsupportedAggregateDetectedEventHandler UnsupportedAggregateDetected;
 
         void Reconcile(IEnumerable<DomainEvent> events);

--- a/src/MooVC.Architecture/MooVC.Architecture.csproj
+++ b/src/MooVC.Architecture/MooVC.Architecture.csproj
@@ -4,7 +4,7 @@
     <Authors>Paul Martins</Authors>
     <CodeAnalysisRuleSet>../../stylecop.analyzers.ruleset</CodeAnalysisRuleSet>
     <Company>MooVC</Company>
-    <Copyright>MooVC © 2019</Copyright>
+    <Copyright>MooVC © 2019-2020</Copyright>
     <Description>A framework designed to support the rapid development of applications that adhere to the Domain Driven Design architectural style.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <LangVersion>latest</LangVersion>

--- a/src/MooVC.Architecture/Resources.Designer.cs
+++ b/src/MooVC.Architecture/Resources.Designer.cs
@@ -180,6 +180,24 @@ namespace MooVC.Architecture {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A reference to the aggregate that was successfull reconciled must be provided..
+        /// </summary>
+        internal static string AggregateReconciledEventArgsAggregateRequired {
+            get {
+                return ResourceManager.GetString("AggregateReconciledEventArgsAggregateRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The events that were successfully reconciled must be provided..
+        /// </summary>
+        internal static string AggregateReconciledEventArgsEventsRequired {
+            get {
+                return ResourceManager.GetString("AggregateReconciledEventArgsEventsRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The factory from which aggregate type specific reconcilation proxies are produced must be provided..
         /// </summary>
         internal static string AggregateReconcilerFactoryRequired {

--- a/src/MooVC.Architecture/Resources.resx
+++ b/src/MooVC.Architecture/Resources.resx
@@ -158,6 +158,12 @@
   <data name="AggregateNotFoundExceptionMessage" xml:space="preserve">
     <value>There is currently no aggregate of type {1} with an ID of {0:p}.</value>
   </data>
+  <data name="AggregateReconciledEventArgsAggregateRequired" xml:space="preserve">
+    <value>A reference to the aggregate that was successfull reconciled must be provided.</value>
+  </data>
+  <data name="AggregateReconciledEventArgsEventsRequired" xml:space="preserve">
+    <value>The events that were successfully reconciled must be provided.</value>
+  </data>
   <data name="AggregateReconcilerFactoryRequired" xml:space="preserve">
     <value>The factory from which aggregate type specific reconcilation proxies are produced must be provided.</value>
   </data>


### PR DESCRIPTION
<b>Enhancements</b>
<ul>
<li>The IAggregateReconciler now supports an event that is to be raised whenever its implementation successfully reconciles an aggregate (<b>Breaking Change</b>).</li>
<li>The DefaultAggregateReconciler now raises an event whenever its implementation successfully reconciles an aggregate.</li>
<li>The AggregateConflictDetectedEventArgs now accepts a Reference to an aggregate, rather than a VersionedReference.</li>
</ul>