### PR TITLE
4.0.1: Version Reset

### DIFF
--- a/src/MooVC.Architecture.Tests/Ddd/EventCentricAggregateRootTests/WhenLoadFromHistoryIsCalled.cs
+++ b/src/MooVC.Architecture.Tests/Ddd/EventCentricAggregateRootTests/WhenLoadFromHistoryIsCalled.cs
@@ -1,0 +1,80 @@
+﻿namespace MooVC.Architecture.Ddd.EventCentricAggregateRootTests
+{
+    using System;
+    using System.Collections.Generic;
+    using MooVC.Architecture.MessageTests;
+    using MooVC.Serialization;
+    using Xunit;
+
+    public sealed class WhenLoadFromHistoryIsCalled
+    {
+        [Fact]
+        public void GivenEventsStartingFromTheBeginningThenTheHydratedAggregateMatchesTheOriginal()
+        {
+            var original = new SerializableEventCentricAggregateRoot();
+            var context = new SerializableMessage();
+
+            IEnumerable<DomainEvent> events = CommitChanges(original, context, times: 1);
+
+            var hydrated = new SerializableEventCentricAggregateRoot(original.Id);
+
+            hydrated.LoadFromHistory(events);
+
+            Assert.Equal(original, hydrated);
+            Assert.Equal(original.Value, hydrated.Value);
+        }
+
+        [Fact]
+        public void GivenEventsStartingFromTheBeginningContainingMultipleVersionsThenTheHydratedAggregateMatchesTheOriginal()
+        {
+            var original = new SerializableEventCentricAggregateRoot();
+            var context = new SerializableMessage();
+
+            IEnumerable<DomainEvent> events = CommitChanges(original, context);
+
+            var hydrated = new SerializableEventCentricAggregateRoot(original.Id);
+
+            hydrated.LoadFromHistory(events);
+
+            Assert.Equal(original, hydrated);
+            Assert.Equal(original.Value, hydrated.Value);
+        }
+
+        [Fact]
+        public void GivenEventsStartingFromAPreviouslyCommittedVersionThenTheHydratedAggregateMatchesTheOriginal()
+        {
+            var original = new SerializableEventCentricAggregateRoot();
+            var context = new SerializableMessage();
+
+            _ = CommitChanges(original, context, times: 1);
+
+            SerializableEventCentricAggregateRoot hydrated = original.Clone();
+
+            IEnumerable<DomainEvent> events = CommitChanges(original, context);
+
+            hydrated.LoadFromHistory(events);
+
+            Assert.Equal(original, hydrated);
+            Assert.Equal(original.Value, hydrated.Value);
+        }
+
+        private static IEnumerable<DomainEvent> CommitChanges(
+            SerializableEventCentricAggregateRoot original,
+            SerializableMessage context,
+            int times = 3)
+        {
+            var events = new List<DomainEvent>();
+
+            for (int index = 0; index < times; index++)
+            {
+                original.Set(new SetRequest(context, Guid.NewGuid()));
+
+                events.AddRange(original.GetUncommittedChanges());
+
+                original.MarkChangesAsCommitted();
+            }
+
+            return events;
+        }
+    }
+}

--- a/src/MooVC.Architecture.Tests/Ddd/SignedVersionTests/WhenSignedVersionIsOrdered.cs
+++ b/src/MooVC.Architecture.Tests/Ddd/SignedVersionTests/WhenSignedVersionIsOrdered.cs
@@ -1,0 +1,45 @@
+﻿namespace MooVC.Architecture.Ddd.SignedVersionTests
+{
+    using System.Linq;
+    using MooVC.Architecture.Ddd.AggregateRootTests;
+    using Xunit;
+
+    public sealed class WhenSignedVersionIsOrdered
+    {
+        [Fact]
+        public void GivenAnUnorderedSequenceThenTheSequencedIsOrderedAscending()
+        {
+            Prepare(out SignedVersion first, out SignedVersion second, out SignedVersion third, out SignedVersion[] sequence);
+
+            SignedVersion[] expected = new[] { first, second, third };
+            SignedVersion[] actual = sequence.OrderBy(version => version).ToArray();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void GivenAnUnorderedSequenceThenTheSequencedIsOrderedDescending()
+        {
+            Prepare(out SignedVersion first, out SignedVersion second, out SignedVersion third, out SignedVersion[] sequence);
+
+            SignedVersion[] expected = new[] { third, second, first };
+            SignedVersion[] actual = sequence.OrderByDescending(version => version).ToArray();
+
+            Assert.Equal(expected, actual);
+        }
+
+        private void Prepare(
+            out SignedVersion first,
+            out SignedVersion second,
+            out SignedVersion third,
+            out SignedVersion[] sequence)
+        {
+            var aggregate = new SerializableAggregateRoot();
+
+            first = aggregate.Version;
+            second = first.Next();
+            third = second.Next();
+            sequence = new[] { first, third, second };
+        }
+    }
+}

--- a/src/MooVC.Architecture/Ddd/AggregateRoot.cs
+++ b/src/MooVC.Architecture/Ddd/AggregateRoot.cs
@@ -20,7 +20,7 @@
                 value => value != Guid.Empty,
                 GenericIdInvalid);
 
-            State = new AggregateState(new SignedVersion(), null);
+            State = new AggregateState(new SignedVersion(), SignedVersion.Empty);
         }
 
         protected AggregateRoot(SerializationInfo info, StreamingContext context)

--- a/src/MooVC.Architecture/Resources.Designer.cs
+++ b/src/MooVC.Architecture/Resources.Designer.cs
@@ -405,6 +405,15 @@ namespace MooVC.Architecture {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The footer of previous version {0} is invalid..
+        /// </summary>
+        internal static string SignedVersionPreviousFooterInvalid {
+            get {
+                return ResourceManager.GetString("SignedVersionPreviousFooterInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The previous version must be provided..
         /// </summary>
         internal static string SignedVersionPreviousRequired {

--- a/src/MooVC.Architecture/Resources.resx
+++ b/src/MooVC.Architecture/Resources.resx
@@ -233,6 +233,9 @@
   <data name="PersistentBusStoreRequired" xml:space="preserve">
     <value>The storage that support persistence of domain events published via the bus must be provided.</value>
   </data>
+  <data name="SignedVersionPreviousFooterInvalid" xml:space="preserve">
+    <value>The footer of previous version {0} is invalid.</value>
+  </data>
   <data name="SignedVersionPreviousRequired" xml:space="preserve">
     <value>The previous version must be provided.</value>
   </data>


### PR DESCRIPTION
<b>Bug Fixes</b>
<ul>
<li>Fixed a bug that would cause the version for an aggregate to reset to a null version if a rollback was triggered on an initial version.</li>
<li>Fixed a bug that prevented the successful generation of a signature for an SignedVersion.</li>
</ul>