### PR TITLE
4.0.2: SignedVersion Serialization Fixes

### DIFF
--- a/src/MooVC.Architecture.Tests/Ddd/EventCentricAggregateRootTests/WhenLoadFromHistoryIsCalled.cs
+++ b/src/MooVC.Architecture.Tests/Ddd/EventCentricAggregateRootTests/WhenLoadFromHistoryIsCalled.cs
@@ -11,6 +11,8 @@
         [Fact]
         public void GivenEventsStartingFromTheBeginningThenTheHydratedAggregateMatchesTheOriginal()
         {
+            const ulong ExpectedVersionNumer = 1;
+
             var original = new SerializableEventCentricAggregateRoot();
             var context = new SerializableMessage();
 
@@ -22,11 +24,14 @@
 
             Assert.Equal(original, hydrated);
             Assert.Equal(original.Value, hydrated.Value);
+            Assert.Equal(ExpectedVersionNumer, hydrated.Version.Number);
         }
 
         [Fact]
         public void GivenEventsStartingFromTheBeginningContainingMultipleVersionsThenTheHydratedAggregateMatchesTheOriginal()
         {
+            const ulong ExpectedVersionNumer = 3;
+
             var original = new SerializableEventCentricAggregateRoot();
             var context = new SerializableMessage();
 
@@ -38,11 +43,14 @@
 
             Assert.Equal(original, hydrated);
             Assert.Equal(original.Value, hydrated.Value);
+            Assert.Equal(ExpectedVersionNumer, hydrated.Version.Number);
         }
 
         [Fact]
         public void GivenEventsStartingFromAPreviouslyCommittedVersionThenTheHydratedAggregateMatchesTheOriginal()
         {
+            const ulong ExpectedVersionNumer = 4;
+
             var original = new SerializableEventCentricAggregateRoot();
             var context = new SerializableMessage();
 
@@ -56,6 +64,7 @@
 
             Assert.Equal(original, hydrated);
             Assert.Equal(original.Value, hydrated.Value);
+            Assert.Equal(ExpectedVersionNumer, hydrated.Version.Number);
         }
 
         private static IEnumerable<DomainEvent> CommitChanges(


### PR DESCRIPTION
<b>Bug Fixes</b>
<ul>
<li>SignedVersion now uses the new TryGetEnumerable/TryAddEnumerable variants to serialize the headers due to concerns of type differences resulting in a default.</li>
</ul>