### PR TITLE
4.3.0: EventCentricAggregateRoot Handler Resolution Enhancements 

### DIFF
--- a/src/MooVC.Architecture.Tests/Ddd/ValueTests/TestValue.cs
+++ b/src/MooVC.Architecture.Tests/Ddd/ValueTests/TestValue.cs
@@ -5,20 +5,24 @@
     public sealed class TestValue
         : Value
     {
-        public TestValue(int a, int b)
+        public TestValue(int a, int b, int c)
         {
             A = a;
             B = b;
+            C = c;
         }
 
         public int A { get; }
 
         public int B { get; }
 
+        public int C { get; }
+
         protected override IEnumerable<object> GetAtomicValues()
         {
             yield return A;
             yield return B;
+            yield return C;
         }
     }
 }

--- a/src/MooVC.Architecture.Tests/Ddd/ValueTests/WhenEqualityIsChecked.cs
+++ b/src/MooVC.Architecture.Tests/Ddd/ValueTests/WhenEqualityIsChecked.cs
@@ -4,29 +4,51 @@
 
     public sealed class WhenEqualityIsChecked
     {
-        [Fact]
-        public void GivenTwoInstancesWithDifferentValuesThenEqualityIsNegative()
+        [Theory]
+        [InlineData(1, 2, 3, 4, 5, 6)]
+        [InlineData(1, 2, 3, 1, 2, 4)]
+        [InlineData(-1, -2, -3, -4, -5, -6)]
+        [InlineData(1, 0, 0, 0, 0, 1)]
+        [InlineData(0, 0, 1, 1, 0, 0)]
+        [InlineData(1, 0, 1, 0, 1, 0)]
+        [InlineData(-1, 0, 0, 0, 0, -1)]
+        [InlineData(0, 0, -1, -1, 0, 0)]
+        [InlineData(-1, 0, -1, 0, -1, 0)]
+        [InlineData(-1, 0, 1, 1, 0, -1)]
+        [InlineData(1, 0, 1, -1, 0, -1)]
+        public void GivenTwoInstancesWithDifferentValuesThenEqualityIsNegative(
+            int firstA,
+            int firstB,
+            int firstC,
+            int secondA,
+            int secondB,
+            int secondC)
         {
-            var value1 = new TestValue(1, 2);
-            var value2 = new TestValue(3, 4);
+            var value1 = new TestValue(firstA, firstB, firstC);
+            var value2 = new TestValue(secondA, secondB, secondC);
 
             Assert.NotEqual(value1, value2);
         }
 
-        [Fact]
-        public void GivenTwoInstancesWithEqualValuesThenEqualityIsPositive()
+        [Theory]
+        [InlineData(0, 0, 0)]
+        [InlineData(1, 2, 3)]
+        public void GivenTwoInstancesWithEqualValuesThenEqualityIsPositive(int valueA, int valueB, int valueC)
         {
-            var value1 = new TestValue(1, 2);
-            var value2 = new TestValue(1, 2);
+            var value1 = new TestValue(valueA, valueB, valueC);
+            var value2 = new TestValue(valueA, valueB, valueC);
 
+            Assert.NotSame(value1, value2);
             Assert.Equal(value1, value2);
         }
 
-        [Fact]
-        public void GivenTwoInstancesWithTheSameValuesButInADifferentOrderThenEqualityIsNegative()
+        [Theory]
+        [InlineData(1, 2, 3)]
+        [InlineData(-1, -2, -3)]
+        public void GivenTwoInstancesWithTheSameValuesButInADifferentOrderThenEqualityIsNegative(int valueA, int valueB, int valueC)
         {
-            var value1 = new TestValue(1, 2);
-            var value2 = new TestValue(2, 1);
+            var value1 = new TestValue(valueA, valueB, valueC);
+            var value2 = new TestValue(valueC, valueB, valueA);
 
             Assert.NotEqual(value1, value2);
         }


### PR DESCRIPTION
<b>Enhancements</b>

<ul>
 <li>The handler resolution behavior of the EventCentricAggregateRoot can now be overridden through the ResolveHandler method.</li>
<li>The default handler resolution behavior of the EventCentricAggregateRoot now caches the results to improve performance when loading from history.</li>
</ul>

<b>Bug Fixes</b>

<ul>
 <li>Fixed a bug that resulted in two Value types with similar properties yielding the same result when calling GetHashCode.</li>
</ul>