### PR TITLE
Extended AtomicUnit to include a proxy for the aggregate reference

### DIFF
--- a/src/MooVC.Architecture.Tests/Ddd/Services/AtomicUnitTests/WhenAtomicUnitIsConstructed.cs
+++ b/src/MooVC.Architecture.Tests/Ddd/Services/AtomicUnitTests/WhenAtomicUnitIsConstructed.cs
@@ -35,6 +35,18 @@
         }
 
         [Fact]
+        public void GiveEventsFromASingleAggregateVersionButTwoDifferentContextsThenAnArgumentExceptionIsThrown()
+        {
+            var version = new SerializableAggregateRoot().ToVersionedReference();
+            var firstContext = new SerializableMessage();
+            var secondContext = new SerializableMessage();
+            var firstEvent = new SerializableDomainEvent(firstContext, version);
+            var secondEvent = new SerializableDomainEvent(secondContext, version);
+
+            _ = Assert.Throws<ArgumentException>(() => new AtomicUnit(firstEvent, secondEvent));
+        }
+
+        [Fact]
         public void GiveEventsFromTwoAggregatesThenAnArgumentExceptionIsThrown()
         {
             var firstVersion = new SerializableAggregateRoot().ToVersionedReference();

--- a/src/MooVC.Architecture/Resources.Designer.cs
+++ b/src/MooVC.Architecture/Resources.Designer.cs
@@ -252,6 +252,15 @@ namespace MooVC.Architecture {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The atomic unit must only contain changes triggered in the context of a single operation..
+        /// </summary>
+        internal static string AtomicUnitDistinctContextRequired {
+            get {
+                return ResourceManager.GetString("AtomicUnitDistinctContextRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The atomic unit must contain one or more domain events..
         /// </summary>
         internal static string AtomicUnitEventsRequired {

--- a/src/MooVC.Architecture/Resources.resx
+++ b/src/MooVC.Architecture/Resources.resx
@@ -182,6 +182,9 @@
   <data name="AtomicUnitDistinctAggregateVersionRequired" xml:space="preserve">
     <value>The atomic unit must only contain changes relating to a single version increment of a single aggregate.</value>
   </data>
+  <data name="AtomicUnitDistinctContextRequired" xml:space="preserve">
+    <value>The atomic unit must only contain changes triggered in the context of a single operation.</value>
+  </data>
   <data name="AtomicUnitEventsRequired" xml:space="preserve">
     <value>The atomic unit must contain one or more domain events.</value>
   </data>


### PR DESCRIPTION
AtomicUnit will now check to ensure the contents all relate to the same transactional context