### PR TITLE
Event Argument Serialization

### DIFF
--- a/src/MooVC.Architecture.Tests/Ddd/Services/AggregateSavedEventArgsTests/WhenAggregateSavedEventArgsIsConstructed.cs
+++ b/src/MooVC.Architecture.Tests/Ddd/Services/AggregateSavedEventArgsTests/WhenAggregateSavedEventArgsIsConstructed.cs
@@ -1,0 +1,30 @@
+﻿namespace MooVC.Architecture.Ddd.Services.AggregateSavedEventArgsTests
+{
+    using System;
+    using MooVC.Architecture.Ddd.AggregateRootTests;
+    using Xunit;
+
+    public sealed class WhenAggregateSavedEventArgsIsConstructed
+    {
+        [Fact]
+        public void GivenAnAggregateThenAnInstanceIsCreated()
+        {
+            var aggregate = new SerializableAggregateRoot();
+            var @event = new AggregateSavedEventArgs<SerializableAggregateRoot>(aggregate);
+
+            Assert.Equal(aggregate, @event.Aggregate);
+            Assert.Same(aggregate, @event.Aggregate);
+        }
+
+        [Fact]
+        public void GivenANullAggregateThenAnArgumentNullExceptionIsThrown()
+        {
+            SerializableAggregateRoot aggregate = default;
+
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new AggregateSavedEventArgs<SerializableAggregateRoot>(aggregate));
+
+            Assert.Equal(nameof(aggregate), exception.ParamName);
+        }
+    }
+}

--- a/src/MooVC.Architecture.Tests/Ddd/Services/AggregateSavedEventArgsTests/WhenAggregateSavedEventArgsIsSerialized.cs
+++ b/src/MooVC.Architecture.Tests/Ddd/Services/AggregateSavedEventArgsTests/WhenAggregateSavedEventArgsIsSerialized.cs
@@ -1,0 +1,22 @@
+﻿namespace MooVC.Architecture.Ddd.Services.AggregateSavedEventArgsTests
+{
+    using MooVC.Architecture.Ddd.AggregateRootTests;
+    using MooVC.Serialization;
+    using Xunit;
+
+    public sealed class WhenAggregateSavedEventArgsIsSerialized
+    {
+        [Fact]
+        public void GivenAnInstanceThenAllPropertiesAreSerialized()
+        {
+            var aggregate = new SerializableAggregateRoot();
+            var @event = new AggregateSavedEventArgs<SerializableAggregateRoot>(aggregate);
+
+            AggregateSavedEventArgs<SerializableAggregateRoot> deserialized = @event.Clone();
+
+            Assert.Equal(@event.Aggregate, deserialized.Aggregate);
+            Assert.NotSame(@event.Aggregate, deserialized.Aggregate);
+            Assert.NotSame(@event, deserialized);
+        }
+    }
+}

--- a/src/MooVC.Architecture.Tests/Ddd/Services/AggregateSavingEventArgsTests/WhenAggregateSavingEventArgsIsConstructed.cs
+++ b/src/MooVC.Architecture.Tests/Ddd/Services/AggregateSavingEventArgsTests/WhenAggregateSavingEventArgsIsConstructed.cs
@@ -1,0 +1,30 @@
+﻿namespace MooVC.Architecture.Ddd.Services.AggregateSavingEventArgsTests
+{
+    using System;
+    using MooVC.Architecture.Ddd.AggregateRootTests;
+    using Xunit;
+
+    public sealed class WhenAggregateSavingEventArgsIsConstructed
+    {
+        [Fact]
+        public void GivenAnAggregateThenAnInstanceIsCreated()
+        {
+            var aggregate = new SerializableAggregateRoot();
+            var @event = new AggregateSavingEventArgs<SerializableAggregateRoot>(aggregate);
+
+            Assert.Equal(aggregate, @event.Aggregate);
+            Assert.Same(aggregate, @event.Aggregate);
+        }
+
+        [Fact]
+        public void GivenANullAggregateThenAnArgumentNullExceptionIsThrown()
+        {
+            SerializableAggregateRoot aggregate = default;
+
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new AggregateSavingEventArgs<SerializableAggregateRoot>(aggregate));
+
+            Assert.Equal(nameof(aggregate), exception.ParamName);
+        }
+    }
+}

--- a/src/MooVC.Architecture.Tests/Ddd/Services/AggregateSavingEventArgsTests/WhenAggregateSavingEventArgsIsSerialized.cs
+++ b/src/MooVC.Architecture.Tests/Ddd/Services/AggregateSavingEventArgsTests/WhenAggregateSavingEventArgsIsSerialized.cs
@@ -1,0 +1,22 @@
+﻿namespace MooVC.Architecture.Ddd.Services.AggregateSavingEventArgsTests
+{
+    using MooVC.Architecture.Ddd.AggregateRootTests;
+    using MooVC.Serialization;
+    using Xunit;
+
+    public sealed class WhenAggregateSavingEventArgsIsSerialized
+    {
+        [Fact]
+        public void GivenAnInstanceThenAllPropertiesAreSerialized()
+        {
+            var aggregate = new SerializableAggregateRoot();
+            var @event = new AggregateSavingEventArgs<SerializableAggregateRoot>(aggregate);
+
+            AggregateSavingEventArgs<SerializableAggregateRoot> deserialized = @event.Clone();
+
+            Assert.Equal(@event.Aggregate, deserialized.Aggregate);
+            Assert.NotSame(@event.Aggregate, deserialized.Aggregate);
+            Assert.NotSame(@event, deserialized);
+        }
+    }
+}

--- a/src/MooVC.Architecture.Tests/Ddd/Services/DomainEventsEventArgsTests/DomainEventsEventArgsBase.cs
+++ b/src/MooVC.Architecture.Tests/Ddd/Services/DomainEventsEventArgsTests/DomainEventsEventArgsBase.cs
@@ -1,0 +1,23 @@
+﻿namespace MooVC.Architecture.Ddd.Services.DomainEventsEventArgsTests
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using MooVC.Architecture.Ddd.AggregateRootTests;
+    using MooVC.Architecture.Ddd.DomainEventTests;
+    using MooVC.Architecture.MessageTests;
+
+    public abstract class DomainEventsEventArgsBase
+    {
+        protected IEnumerable<DomainEvent> CreateEvents(int count)
+        {
+            var context = new SerializableMessage();
+            var aggregate = new SerializableAggregateRoot();
+            var version = aggregate.ToVersionedReference();
+
+            return Enumerable
+                .Range(0, count)
+                .Select(_ => new SerializableDomainEvent(context, version))
+                .ToArray();
+        }
+    }
+}

--- a/src/MooVC.Architecture.Tests/Ddd/Services/DomainEventsPublishedEventArgsTests/WhenDomainEventsPublishedEventArgsIsConstructed.cs
+++ b/src/MooVC.Architecture.Tests/Ddd/Services/DomainEventsPublishedEventArgsTests/WhenDomainEventsPublishedEventArgsIsConstructed.cs
@@ -1,0 +1,30 @@
+﻿namespace MooVC.Architecture.Ddd.Services.DomainEventsPublishedEventArgsTests
+{
+    using System.Collections.Generic;
+    using MooVC.Architecture.Ddd.Services.DomainEventsEventArgsTests;
+    using Xunit;
+
+    public sealed class WhenDomainEventsPublishedEventArgsIsConstructed
+        : DomainEventsEventArgsBase
+    {
+        [Fact]
+        public void GivenNullEventsThenAnInstanceIsCreated()
+        {
+            var @event = new DomainEventsPublishedEventArgs(default);
+
+            Assert.Empty(@event.Events);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(5)]
+        public void GivenEventsThenAnInstanceIsCreated(int count)
+        {
+            IEnumerable<DomainEvent> events = CreateEvents(count);
+            var @event = new DomainEventsPublishedEventArgs(events);
+
+            Assert.NotSame(events, @event.Events);
+        }
+    }
+}

--- a/src/MooVC.Architecture.Tests/Ddd/Services/DomainEventsPublishedEventArgsTests/WhenDomainEventsPublishedEventArgsIsSerialized.cs
+++ b/src/MooVC.Architecture.Tests/Ddd/Services/DomainEventsPublishedEventArgsTests/WhenDomainEventsPublishedEventArgsIsSerialized.cs
@@ -1,0 +1,34 @@
+﻿namespace MooVC.Architecture.Ddd.Services.DomainEventsPublishedEventArgsTests
+{
+    using System.Collections.Generic;
+    using MooVC.Architecture.Ddd.Services.DomainEventsEventArgsTests;
+    using MooVC.Serialization;
+    using Xunit;
+
+    public sealed class WhenDomainEventsPublishedEventArgsIsSerialized
+        : DomainEventsEventArgsBase
+    {
+        [Fact]
+        public void GivenNullEventsThenAllPropertiesAreSerialized()
+        {
+            var @event = new DomainEventsPublishedEventArgs(default);
+            DomainEventsPublishedEventArgs deserialized = @event.Clone();
+
+            Assert.NotSame(@event, deserialized);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(5)]
+        public void GivenEventsThenAllPropertiesAreSerialized(int count)
+        {
+            IEnumerable<DomainEvent> events = CreateEvents(count);
+            var @event = new DomainEventsPublishedEventArgs(events);
+
+            DomainEventsPublishedEventArgs deserialized = @event.Clone();
+
+            Assert.NotSame(@event, deserialized);
+        }
+    }
+}

--- a/src/MooVC.Architecture.Tests/Ddd/Services/DomainEventsPublishingEventArgsTests/WhenDomainEventsPublishingEventArgsIsConstructed.cs
+++ b/src/MooVC.Architecture.Tests/Ddd/Services/DomainEventsPublishingEventArgsTests/WhenDomainEventsPublishingEventArgsIsConstructed.cs
@@ -1,0 +1,30 @@
+﻿namespace MooVC.Architecture.Ddd.Services.DomainEventsPublishingEventArgsTests
+{
+    using System.Collections.Generic;
+    using MooVC.Architecture.Ddd.Services.DomainEventsEventArgsTests;
+    using Xunit;
+
+    public sealed class WhenDomainEventsPublishingEventArgsIsConstructed
+        : DomainEventsEventArgsBase
+    {
+        [Fact]
+        public void GivenNullEventsThenAnInstanceIsCreated()
+        {
+            var @event = new DomainEventsPublishingEventArgs(default);
+
+            Assert.Empty(@event.Events);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(5)]
+        public void GivenEventsThenAnInstanceIsCreated(int count)
+        {
+            IEnumerable<DomainEvent> events = CreateEvents(count);
+            var @event = new DomainEventsPublishingEventArgs(events);
+
+            Assert.NotSame(events, @event.Events);
+        }
+    }
+}

--- a/src/MooVC.Architecture.Tests/Ddd/Services/DomainEventsPublishingEventArgsTests/WhenDomainEventsPublishingEventArgsIsSerialized.cs
+++ b/src/MooVC.Architecture.Tests/Ddd/Services/DomainEventsPublishingEventArgsTests/WhenDomainEventsPublishingEventArgsIsSerialized.cs
@@ -1,0 +1,34 @@
+﻿namespace MooVC.Architecture.Ddd.Services.DomainEventsPublishingEventArgsTests
+{
+    using System.Collections.Generic;
+    using MooVC.Architecture.Ddd.Services.DomainEventsEventArgsTests;
+    using MooVC.Serialization;
+    using Xunit;
+
+    public sealed class WhenDomainEventsPublishingEventArgsIsSerialized
+        : DomainEventsEventArgsBase
+    {
+        [Fact]
+        public void GivenNullEventsThenAllPropertiesAreSerialized()
+        {
+            var @event = new DomainEventsPublishingEventArgs(default);
+            DomainEventsPublishingEventArgs deserialized = @event.Clone();
+
+            Assert.NotSame(@event, deserialized);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(5)]
+        public void GivenEventsThenAllPropertiesAreSerialized(int count)
+        {
+            IEnumerable<DomainEvent> events = CreateEvents(count);
+            var @event = new DomainEventsPublishingEventArgs(events);
+
+            DomainEventsPublishingEventArgs deserialized = @event.Clone();
+
+            Assert.NotSame(@event, deserialized);
+        }
+    }
+}

--- a/src/MooVC.Architecture.Tests/Services/MessageInvokedEventArgsTests/WhenMessageInvokedEventArgsIsConstructed.cs
+++ b/src/MooVC.Architecture.Tests/Services/MessageInvokedEventArgsTests/WhenMessageInvokedEventArgsIsConstructed.cs
@@ -1,0 +1,30 @@
+﻿namespace MooVC.Architecture.Services.MessageInvokedEventArgsTests
+{
+    using System;
+    using MooVC.Architecture.MessageTests;
+    using Xunit;
+
+    public sealed class WhenMessageInvokedEventArgsIsConstructed
+    {
+        [Fact]
+        public void GivenAnAggregateThenAnInstanceIsCreated()
+        {
+            var message = new SerializableMessage();
+            var @event = new MessageInvokedEventArgs(message);
+
+            Assert.Equal(message, @event.Message);
+            Assert.Same(message, @event.Message);
+        }
+
+        [Fact]
+        public void GivenANullAggregateThenAnArgumentNullExceptionIsThrown()
+        {
+            SerializableMessage message = default;
+
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new MessageInvokedEventArgs(message));
+
+            Assert.Equal(nameof(message), exception.ParamName);
+        }
+    }
+}

--- a/src/MooVC.Architecture.Tests/Services/MessageInvokedEventArgsTests/WhenMessageInvokedEventArgsIsSerialized.cs
+++ b/src/MooVC.Architecture.Tests/Services/MessageInvokedEventArgsTests/WhenMessageInvokedEventArgsIsSerialized.cs
@@ -1,0 +1,22 @@
+﻿namespace MooVC.Architecture.Services.MessageInvokedEventArgsTests
+{
+    using MooVC.Architecture.MessageTests;
+    using MooVC.Serialization;
+    using Xunit;
+
+    public sealed class WhenMessageInvokedEventArgsIsSerialized
+    {
+        [Fact]
+        public void GivenAnInstanceThenAllPropertiesAreSerialized()
+        {
+            var message = new SerializableMessage();
+            var @event = new MessageInvokedEventArgs(message);
+
+            MessageInvokedEventArgs deserialized = @event.Clone();
+
+            Assert.Equal(@event.Message, deserialized.Message);
+            Assert.NotSame(@event.Message, deserialized.Message);
+            Assert.NotSame(@event, deserialized);
+        }
+    }
+}

--- a/src/MooVC.Architecture.Tests/Services/MessageInvokingEventArgsTests/WhenMessageInvokingEventArgsIsConstructed.cs
+++ b/src/MooVC.Architecture.Tests/Services/MessageInvokingEventArgsTests/WhenMessageInvokingEventArgsIsConstructed.cs
@@ -1,0 +1,30 @@
+﻿namespace MooVC.Architecture.Services.MessageInvokingEventArgsTests
+{
+    using System;
+    using MooVC.Architecture.MessageTests;
+    using Xunit;
+
+    public sealed class WhenMessageInvokingEventArgsIsConstructed
+    {
+        [Fact]
+        public void GivenAnAggregateThenAnInstanceIsCreated()
+        {
+            var message = new SerializableMessage();
+            var @event = new MessageInvokingEventArgs(message);
+
+            Assert.Equal(message, @event.Message);
+            Assert.Same(message, @event.Message);
+        }
+
+        [Fact]
+        public void GivenANullAggregateThenAnArgumentNullExceptionIsThrown()
+        {
+            SerializableMessage message = default;
+
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new MessageInvokingEventArgs(message));
+
+            Assert.Equal(nameof(message), exception.ParamName);
+        }
+    }
+}

--- a/src/MooVC.Architecture.Tests/Services/MessageInvokingEventArgsTests/WhenMessageInvokingEventArgsIsSerialized.cs
+++ b/src/MooVC.Architecture.Tests/Services/MessageInvokingEventArgsTests/WhenMessageInvokingEventArgsIsSerialized.cs
@@ -1,0 +1,22 @@
+﻿namespace MooVC.Architecture.Services.MessageInvokingEventArgsTests
+{
+    using MooVC.Architecture.MessageTests;
+    using MooVC.Serialization;
+    using Xunit;
+
+    public sealed class WhenMessageInvokingEventArgsIsSerialized
+    {
+        [Fact]
+        public void GivenAnInstanceThenAllPropertiesAreSerialized()
+        {
+            var message = new SerializableMessage();
+            var @event = new MessageInvokingEventArgs(message);
+
+            MessageInvokingEventArgs deserialized = @event.Clone();
+
+            Assert.Equal(@event.Message, deserialized.Message);
+            Assert.NotSame(@event.Message, deserialized.Message);
+            Assert.NotSame(@event, deserialized);
+        }
+    }
+}

--- a/src/MooVC.Architecture/Ddd/AggregateEventArgs.cs
+++ b/src/MooVC.Architecture/Ddd/AggregateEventArgs.cs
@@ -1,11 +1,16 @@
 namespace MooVC.Architecture.Ddd.Services
 {
     using System;
+    using System.Runtime.Serialization;
+    using System.Security.Permissions;
+    using MooVC.Serialization;
     using static MooVC.Ensure;
     using static Resources;
 
+    [Serializable]
     public abstract class AggregateEventArgs<TAggregate>
-        : EventArgs
+        : EventArgs,
+          ISerializable
         where TAggregate : AggregateRoot
     {
         protected AggregateEventArgs(TAggregate aggregate)
@@ -15,6 +20,17 @@ namespace MooVC.Architecture.Ddd.Services
             Aggregate = aggregate;
         }
 
+        protected AggregateEventArgs(SerializationInfo info, StreamingContext context)
+        {
+            Aggregate = info.GetValue<TAggregate>(nameof(Aggregate));
+        }
+
         public TAggregate Aggregate { get; }
+
+        [SecurityPermission(SecurityAction.LinkDemand, Flags = SecurityPermissionFlag.SerializationFormatter)]
+        public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue(nameof(Aggregate), Aggregate);
+        }
     }
 }

--- a/src/MooVC.Architecture/Ddd/ChangesMarkedAsCommittedEventArgs.cs
+++ b/src/MooVC.Architecture/Ddd/ChangesMarkedAsCommittedEventArgs.cs
@@ -2,16 +2,32 @@ namespace MooVC.Architecture.Ddd
 {
     using System;
     using System.Collections.Generic;
+    using System.Runtime.Serialization;
+    using System.Security.Permissions;
     using MooVC.Collections.Generic;
+    using MooVC.Serialization;
 
+    [Serializable]
     public sealed class ChangesMarkedAsCommittedEventArgs
-        : EventArgs
+        : EventArgs,
+          ISerializable
     {
         internal ChangesMarkedAsCommittedEventArgs(IEnumerable<DomainEvent> changes)
         {
             Changes = changes.Snapshot();
         }
 
+        private ChangesMarkedAsCommittedEventArgs(SerializationInfo info, StreamingContext context)
+        {
+            Changes = info.TryGetEnumerable<DomainEvent>(nameof(Changes));
+        }
+
         public IEnumerable<DomainEvent> Changes { get; }
+
+        [SecurityPermission(SecurityAction.LinkDemand, Flags = SecurityPermissionFlag.SerializationFormatter)]
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            _ = info.TryAddEnumerable(nameof(Changes), Changes);
+        }
     }
 }

--- a/src/MooVC.Architecture/Ddd/Services/AggregateSavedEventArgs.cs
+++ b/src/MooVC.Architecture/Ddd/Services/AggregateSavedEventArgs.cs
@@ -1,11 +1,20 @@
 namespace MooVC.Architecture.Ddd.Services
 {
+    using System;
+    using System.Runtime.Serialization;
+
+    [Serializable]
     public sealed class AggregateSavedEventArgs<TAggregate>
         : AggregateEventArgs<TAggregate>
         where TAggregate : AggregateRoot
     {
         public AggregateSavedEventArgs(TAggregate aggregate)
             : base(aggregate)
+        {
+        }
+
+        private AggregateSavedEventArgs(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/MooVC.Architecture/Ddd/Services/AggregateSavingEventArgs.cs
+++ b/src/MooVC.Architecture/Ddd/Services/AggregateSavingEventArgs.cs
@@ -1,11 +1,20 @@
 namespace MooVC.Architecture.Ddd.Services
 {
+    using System;
+    using System.Runtime.Serialization;
+
+    [Serializable]
     public sealed class AggregateSavingEventArgs<TAggregate>
         : AggregateEventArgs<TAggregate>
         where TAggregate : AggregateRoot
     {
         public AggregateSavingEventArgs(TAggregate aggregate)
             : base(aggregate)
+        {
+        }
+
+        private AggregateSavingEventArgs(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/MooVC.Architecture/Ddd/Services/DomainEventsEventArgs.cs
+++ b/src/MooVC.Architecture/Ddd/Services/DomainEventsEventArgs.cs
@@ -2,16 +2,32 @@ namespace MooVC.Architecture.Ddd.Services
 {
     using System;
     using System.Collections.Generic;
+    using System.Runtime.Serialization;
+    using System.Security.Permissions;
     using MooVC.Collections.Generic;
+    using MooVC.Serialization;
 
+    [Serializable]
     public abstract class DomainEventsEventArgs
-        : EventArgs
+        : EventArgs,
+          ISerializable
     {
         protected DomainEventsEventArgs(IEnumerable<DomainEvent> events)
         {
             Events = events.Snapshot();
         }
 
+        protected DomainEventsEventArgs(SerializationInfo info, StreamingContext context)
+        {
+            Events = info.TryGetEnumerable<DomainEvent>(nameof(Events));
+        }
+
         public IEnumerable<DomainEvent> Events { get; }
+
+        [SecurityPermission(SecurityAction.LinkDemand, Flags = SecurityPermissionFlag.SerializationFormatter)]
+        public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            _ = info.TryAddEnumerable(nameof(Events), Events);
+        }
     }
 }

--- a/src/MooVC.Architecture/Ddd/Services/DomainEventsPublishedEventArgs.cs
+++ b/src/MooVC.Architecture/Ddd/Services/DomainEventsPublishedEventArgs.cs
@@ -1,12 +1,20 @@
 ﻿namespace MooVC.Architecture.Ddd.Services
 {
+    using System;
     using System.Collections.Generic;
+    using System.Runtime.Serialization;
 
+    [Serializable]
     public sealed class DomainEventsPublishedEventArgs
         : DomainEventsEventArgs
     {
         public DomainEventsPublishedEventArgs(IEnumerable<DomainEvent> events)
             : base(events)
+        {
+        }
+
+        private DomainEventsPublishedEventArgs(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/MooVC.Architecture/Ddd/Services/DomainEventsPublishingEventArgs.cs
+++ b/src/MooVC.Architecture/Ddd/Services/DomainEventsPublishingEventArgs.cs
@@ -1,12 +1,20 @@
 ﻿namespace MooVC.Architecture.Ddd.Services
 {
+    using System;
     using System.Collections.Generic;
+    using System.Runtime.Serialization;
 
+    [Serializable]
     public sealed class DomainEventsPublishingEventArgs
         : DomainEventsEventArgs
     {
         public DomainEventsPublishingEventArgs(IEnumerable<DomainEvent> events)
             : base(events)
+        {
+        }
+
+        private DomainEventsPublishingEventArgs(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/MooVC.Architecture/Ddd/Services/Reconciliation/AggregateConflictDetectedEventArgs.cs
+++ b/src/MooVC.Architecture/Ddd/Services/Reconciliation/AggregateConflictDetectedEventArgs.cs
@@ -3,13 +3,18 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Runtime.Serialization;
+    using System.Security.Permissions;
     using MooVC.Architecture.Ddd;
+    using MooVC.Serialization;
     using static MooVC.Architecture.Ddd.Ensure;
     using static MooVC.Ensure;
     using static Resources;
 
+    [Serializable]
     public sealed class AggregateConflictDetectedEventArgs
-        : EventArgs
+        : EventArgs,
+          ISerializable
     {
         internal AggregateConflictDetectedEventArgs(
             Reference aggregate,
@@ -28,6 +33,14 @@
             Previous = previous;
         }
 
+        private AggregateConflictDetectedEventArgs(SerializationInfo info, StreamingContext context)
+        {
+            Aggregate = info.TryGetValue<Reference>(nameof(Aggregate));
+            Events = info.TryGetEnumerable<DomainEvent>(nameof(Events));
+            Next = info.GetValue<SignedVersion>(nameof(Next));
+            Previous = info.GetValue<SignedVersion>(nameof(Previous));
+        }
+
         public Reference Aggregate { get; }
 
         public IEnumerable<DomainEvent> Events { get; }
@@ -35,5 +48,14 @@
         public SignedVersion Next { get; }
 
         public SignedVersion Previous { get; }
+
+        [SecurityPermission(SecurityAction.LinkDemand, Flags = SecurityPermissionFlag.SerializationFormatter)]
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            _ = info.TryAddValue(nameof(Aggregate), Aggregate);
+            _ = info.TryAddEnumerable(nameof(Events), Events);
+            info.AddValue(nameof(Next), Next);
+            info.AddValue(nameof(Previous), Previous);
+        }
     }
 }

--- a/src/MooVC.Architecture/Ddd/Services/Reconciliation/AggregateReconciledEventArgs.cs
+++ b/src/MooVC.Architecture/Ddd/Services/Reconciliation/AggregateReconciledEventArgs.cs
@@ -3,13 +3,18 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Runtime.Serialization;
+    using System.Security.Permissions;
     using MooVC.Architecture.Ddd;
+    using MooVC.Serialization;
     using static MooVC.Architecture.Ddd.Ensure;
     using static MooVC.Ensure;
     using static Resources;
 
+    [Serializable]
     public sealed class AggregateReconciledEventArgs
-        : EventArgs
+        : EventArgs,
+          ISerializable
     {
         internal AggregateReconciledEventArgs(
             Reference aggregate,
@@ -22,8 +27,21 @@
             Events = events;
         }
 
+        private AggregateReconciledEventArgs(SerializationInfo info, StreamingContext context)
+        {
+            Aggregate = info.TryGetValue<Reference>(nameof(Aggregate));
+            Events = info.TryGetEnumerable<DomainEvent>(nameof(Events));
+        }
+
         public Reference Aggregate { get; }
 
         public IEnumerable<DomainEvent> Events { get; }
+
+        [SecurityPermission(SecurityAction.LinkDemand, Flags = SecurityPermissionFlag.SerializationFormatter)]
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            _ = info.TryAddValue(nameof(Aggregate), Aggregate);
+            _ = info.TryAddEnumerable(nameof(Events), Events);
+        }
     }
 }

--- a/src/MooVC.Architecture/Ddd/Services/Reconciliation/EventReconciliationEventArgs.cs
+++ b/src/MooVC.Architecture/Ddd/Services/Reconciliation/EventReconciliationEventArgs.cs
@@ -2,13 +2,18 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Runtime.Serialization;
+    using System.Security.Permissions;
     using MooVC.Collections.Generic;
     using MooVC.Linq;
+    using MooVC.Serialization;
     using static MooVC.Ensure;
     using static Resources;
 
+    [Serializable]
     public sealed class EventReconciliationEventArgs
-        : EventArgs
+        : EventArgs,
+          ISerializable
     {
         public EventReconciliationEventArgs(IEnumerable<DomainEvent> events)
         {
@@ -21,6 +26,17 @@
             Events = events.Snapshot();
         }
 
+        private EventReconciliationEventArgs(SerializationInfo info, StreamingContext context)
+        {
+            Events = info.TryGetEnumerable<DomainEvent>(nameof(Events));
+        }
+
         public IEnumerable<DomainEvent> Events { get; }
+
+        [SecurityPermission(SecurityAction.LinkDemand, Flags = SecurityPermissionFlag.SerializationFormatter)]
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            _ = info.TryAddEnumerable(nameof(Events), Events);
+        }
     }
 }

--- a/src/MooVC.Architecture/Ddd/Services/Reconciliation/EventSequenceAdvancedEventArgs.cs
+++ b/src/MooVC.Architecture/Ddd/Services/Reconciliation/EventSequenceAdvancedEventArgs.cs
@@ -1,15 +1,30 @@
 ﻿namespace MooVC.Architecture.Ddd.Services.Reconciliation
 {
     using System;
+    using System.Runtime.Serialization;
+    using System.Security.Permissions;
 
+    [Serializable]
     public sealed class EventSequenceAdvancedEventArgs
-        : EventArgs
+        : EventArgs,
+          ISerializable
     {
         internal EventSequenceAdvancedEventArgs(ulong sequence)
         {
             Sequence = sequence;
         }
 
+        private EventSequenceAdvancedEventArgs(SerializationInfo info, StreamingContext context)
+        {
+            Sequence = info.GetUInt64(nameof(Sequence));
+        }
+
         public ulong Sequence { get; }
+
+        [SecurityPermission(SecurityAction.LinkDemand, Flags = SecurityPermissionFlag.SerializationFormatter)]
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue(nameof(Sequence), Sequence);
+        }
     }
 }

--- a/src/MooVC.Architecture/Resources.Designer.cs
+++ b/src/MooVC.Architecture/Resources.Designer.cs
@@ -522,6 +522,15 @@ namespace MooVC.Architecture {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The message that is the subject of this event must be provided..
+        /// </summary>
+        internal static string MessageEventArgsMessageRequired {
+            get {
+                return ResourceManager.GetString("MessageEventArgsMessageRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The message that serves as the context for coordination must be provided..
         /// </summary>
         internal static string MessageExtensionsCoordinateMessageRequired {

--- a/src/MooVC.Architecture/Resources.resx
+++ b/src/MooVC.Architecture/Resources.resx
@@ -272,6 +272,9 @@
   <data name="HandlerFailureExceptionMessage" xml:space="preserve">
     <value>Handler for message of type {0} has failed to process message {1:p} for transaction {2:p}.</value>
   </data>
+  <data name="MessageEventArgsMessageRequired" xml:space="preserve">
+    <value>The message that is the subject of this event must be provided.</value>
+  </data>
   <data name="MessageExtensionsCoordinateMessageRequired" xml:space="preserve">
     <value>The message that serves as the context for coordination must be provided.</value>
   </data>

--- a/src/MooVC.Architecture/Services/MessageEventArgs.cs
+++ b/src/MooVC.Architecture/Services/MessageEventArgs.cs
@@ -1,15 +1,35 @@
 namespace MooVC.Architecture.Services
 {
     using System;
+    using System.Runtime.Serialization;
+    using System.Security.Permissions;
+    using MooVC.Serialization;
+    using static MooVC.Ensure;
+    using static Resources;
 
+    [Serializable]
     public abstract class MessageEventArgs
-        : EventArgs
+        : EventArgs,
+          ISerializable
     {
         protected MessageEventArgs(Message message)
         {
+            ArgumentNotNull(message, nameof(message), MessageEventArgsMessageRequired);
+
             Message = message;
         }
 
+        protected MessageEventArgs(SerializationInfo info, StreamingContext context)
+        {
+            Message = info.GetValue<Message>(nameof(Message));
+        }
+
         public Message Message { get; }
+
+        [SecurityPermission(SecurityAction.LinkDemand, Flags = SecurityPermissionFlag.SerializationFormatter)]
+        public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue(nameof(Message), Message);
+        }
     }
 }

--- a/src/MooVC.Architecture/Services/MessageInvokedEventArgs.cs
+++ b/src/MooVC.Architecture/Services/MessageInvokedEventArgs.cs
@@ -1,10 +1,19 @@
 ﻿namespace MooVC.Architecture.Services
 {
+    using System;
+    using System.Runtime.Serialization;
+
+    [Serializable]
     public sealed class MessageInvokedEventArgs
         : MessageEventArgs
     {
         public MessageInvokedEventArgs(Message message)
             : base(message)
+        {
+        }
+
+        private MessageInvokedEventArgs(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/MooVC.Architecture/Services/MessageInvokingEventArgs.cs
+++ b/src/MooVC.Architecture/Services/MessageInvokingEventArgs.cs
@@ -1,10 +1,19 @@
 ﻿namespace MooVC.Architecture.Services
 {
+    using System;
+    using System.Runtime.Serialization;
+
+    [Serializable]
     public sealed class MessageInvokingEventArgs
         : MessageEventArgs
     {
         public MessageInvokingEventArgs(Message message)
             : base(message)
+        {
+        }
+
+        private MessageInvokingEventArgs(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }


### PR DESCRIPTION
# Enhancements

- MooVC.Architecture.Services.MessageEventArgs is now marked as serializable.
- MooVC.Architecture.Services.MessageInvokedEventArgs is now marked as serializable.
- MooVC.Architecture.Services.MessageInvokingEventArgs is now marked as serializable.
- MooVC.Architecture.Ddd.ChangesMarkedAsCommittedEventArgs is now marked as serializable.
- MooVC.Architecture.Ddd.Services.AggregateEventArgs is now marked as serializable.
- MooVC.Architecture.Ddd.Services.AggregateSavedEventArgs is now marked as serializable.
- MooVC.Architecture.Ddd.Services.AggregateSavingEventArgs is now marked as serializable.
- MooVC.Architecture.Ddd.Services.DomainEventsEventArgs is now marked as serializable.
- MooVC.Architecture.Ddd.Services.DomainEventsPublishedEventArgs is now marked as serializable.
- MooVC.Architecture.Ddd.Services.DomainEventsPublishingEventArgs is now marked as serializable.
- MooVC.Architecture.Ddd.Services.Reconciliation.AggregateConflictDetectedEventArgs is now marked as serializable.
- MooVC.Architecture.Ddd.Services.Reconciliation.AggregateReconciledEventArgs is now marked as serializable.
- MooVC.Architecture.Ddd.Services.Reconciliation.EventReconciliationEventArgs is now marked as serializable.
- MooVC.Architecture.Ddd.Services.Reconciliation.EventSequenceAdvancedEventArgs is now marked as serializable.

# Bug Fixes

- Fixed a bug that allowed an derivation of MooVC.Architecture.Services.MessageEventArgs to be instantiated without providing an instance of a message.